### PR TITLE
Linked Main menu settings to gameplay

### DIFF
--- a/TOGameJam2021-AiaB/Assets/Scripts/GameManager.cs
+++ b/TOGameJam2021-AiaB/Assets/Scripts/GameManager.cs
@@ -35,6 +35,9 @@ public class GameManager : MonoBehaviour
 
     void Start()
     {
+        //Import the number of rounds and auditions from the settings set by user in main menu
+        numRounds = PlayerPrefs.GetInt("NumberOfRounds") ;
+        numAuditions = PlayerPrefs.GetInt("NumberOfAuditioners");
         if (fullAuditionsList.Count < 1)
             Debug.LogError("Full Auditions List is not yet populated!");
         if (numAuditions < 1)

--- a/TOGameJam2021-AiaB/Assets/Scripts/MainMenu.cs
+++ b/TOGameJam2021-AiaB/Assets/Scripts/MainMenu.cs
@@ -54,6 +54,8 @@ public class MainMenu : MonoBehaviour
 
     public void StartGame()
     {
+        PlayerPrefs.SetInt("NumberOfRounds", NumberOfRounds);
+        PlayerPrefs.SetInt("NumberOfAuditioners", NumberOfEnemies);
         SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex + 1);
     }
     


### PR DESCRIPTION
The number of rounds and number of auditioning characters set in the main menu is passed through to gamemanager